### PR TITLE
SystemUI: remove 'hide clock' option from clock position tunable

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/ClockController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/ClockController.java
@@ -22,9 +22,9 @@ public class ClockController implements TunerService.Tunable {
 
     private static final String TAG = "ClockController";
 
-    public static final int STYLE_CLOCK_RIGHT = 1;
-    public static final int STYLE_CLOCK_CENTER = 2;
-    public static final int STYLE_CLOCK_LEFT = 3;
+    public static final int CLOCK_POSITION_RIGHT = 0;
+    public static final int CLOCK_POSITION_CENTER = 1;
+    public static final int CLOCK_POSITION_LEFT = 2;
 
     public static final String CLOCK_POSITION = "cmsystem:status_bar_clock";
     public static final String CLOCK_STYLE = "cmsystem:status_bar_am_pm";
@@ -34,7 +34,7 @@ public class ClockController implements TunerService.Tunable {
     private Clock mRightClock, mCenterClock, mLeftClock, mActiveClock;
 
     private int mAmPmStyle = AM_PM_STYLE_GONE;
-    private int mClockPosition = STYLE_CLOCK_RIGHT;
+    private int mClockPosition = CLOCK_POSITION_RIGHT;
     private boolean mClockVisible = true;
     private boolean mShowSeconds = false;
 
@@ -56,13 +56,13 @@ public class ClockController implements TunerService.Tunable {
     private Clock getClockForCurrentLocation() {
         Clock clockForAlignment;
         switch (mClockPosition) {
-            case STYLE_CLOCK_CENTER:
+            case CLOCK_POSITION_CENTER:
                 clockForAlignment = mCenterClock;
                 break;
-            case STYLE_CLOCK_LEFT:
+            case CLOCK_POSITION_LEFT:
                 clockForAlignment = mLeftClock;
                 break;
-            case STYLE_CLOCK_RIGHT:
+            case CLOCK_POSITION_RIGHT:
             default:
                 clockForAlignment = mRightClock;
                 break;
@@ -91,7 +91,7 @@ public class ClockController implements TunerService.Tunable {
         Log.d(TAG, "onTuningChanged key=" + key + " value=" + newValue);
 
         if (CLOCK_POSITION.equals(key)) {
-            mClockPosition = newValue == null ? STYLE_CLOCK_RIGHT : Integer.valueOf(newValue);
+            mClockPosition = newValue == null ? CLOCK_POSITION_RIGHT : Integer.valueOf(newValue);
         } else if (CLOCK_STYLE.equals(key)) {
             mAmPmStyle = newValue == null ? AM_PM_STYLE_GONE : Integer.valueOf(newValue);
         } else if (CLOCK_SECONDS.equals(key)) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/IconMerger.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/IconMerger.java
@@ -69,7 +69,7 @@ public class IconMerger extends LinearLayout {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
         // we need to constrain this to an integral multiple of our children
         int width = getMeasuredWidth();
-        if (mClockLocation == ClockController.STYLE_CLOCK_CENTER) {
+        if (mClockLocation == ClockController.CLOCK_POSITION_CENTER) {
             int totalWidth = getResources().getDisplayMetrics().widthPixels;
             width = totalWidth / 2 - getFullIconWidth() * 2;
         }
@@ -94,8 +94,8 @@ public class IconMerger extends LinearLayout {
         // let's assume we have one more slot if the more icon is already showing
         if (overflowShown) {
             int totalWidth = getResources().getDisplayMetrics().widthPixels;
-            if ((mClockLocation != ClockController.STYLE_CLOCK_CENTER &&
-                    mClockLocation != ClockController.STYLE_CLOCK_LEFT) ||
+            if ((mClockLocation != ClockController.CLOCK_POSITION_CENTER &&
+                    mClockLocation != ClockController.CLOCK_POSITION_LEFT) ||
                     (visibleChildren > (totalWidth / getFullIconWidth() / 2 + 1))) {
                 visibleChildren--;
             }


### PR DESCRIPTION
* Hiding the clock is now possible using the icon blacklist.
* Since the the hide option in the clock position tunable isn't currently implemented let's remove it

Change-Id: Ie5f4f5c7bd2dc4d1d3eb1e77ecf8eebc944868e6